### PR TITLE
minor fixes for TS generation and set new definitions

### DIFF
--- a/EN10168-v1.0.schema.json
+++ b/EN10168-v1.0.schema.json
@@ -9,6 +9,7 @@
   "$id": "https://schemas.en10204.io/EN10168-v1.0.schema.json#",
   "definitions": {
     "KeyValueObject": {
+      "title": "KeyValueObject",
       "type": "object",
       "properties": {
         "Key": {
@@ -24,13 +25,16 @@
           "type": "string"
         }
       },
-      "required": [
-        "Key",
-        "Value"
-      ],
+      "required": ["Key", "Value"],
       "additionalProperties": false
     },
+    "Language": {
+      "title": "Language",
+      "type": "string",
+      "enum": ["EN", "DE", "FR", "PL"]
+    },
     "ChemicalElement": {
+      "title": "ChemicalElement",
       "type": "object",
       "description": "The chemical elements of the product.",
       "properties": {
@@ -57,13 +61,11 @@
           "maximum": 1
         }
       },
-      "required": [
-        "Symbol",
-        "Actual"
-      ],
+      "required": ["Symbol", "Actual"],
       "additionalProperties": false
     },
     "Tube": {
+      "title": "Tube",
       "description": "",
       "type": "object",
       "properties": {
@@ -83,14 +85,11 @@
           "minimum": 0
         }
       },
-      "required": [
-        "Form",
-        "OuterDiameter",
-        "WallThickness"
-      ],
+      "required": ["Form", "OuterDiameter", "WallThickness"],
       "additionalProperties": false
     },
     "QuadraticTube": {
+      "title": "QuadraticTube",
       "description": "",
       "type": "object",
       "properties": {
@@ -110,14 +109,11 @@
           "minimum": 0
         }
       },
-      "required": [
-        "Form",
-        "SideLength",
-        "WallThickness"
-      ],
+      "required": ["Form", "SideLength", "WallThickness"],
       "additionalProperties": false
     },
     "RectangularTube": {
+      "title": "RectangularTube",
       "description": "",
       "type": "object",
       "properties": {
@@ -142,15 +138,11 @@
           "minimum": 0
         }
       },
-      "required": [
-        "Form",
-        "Width",
-        "Height",
-        "WallThickness"
-      ],
+      "required": ["Form", "Width", "Height", "WallThickness"],
       "additionalProperties": false
     },
     "Pipe": {
+      "title": "Pipe",
       "description": "",
       "type": "object",
       "properties": {
@@ -170,14 +162,11 @@
           "minimum": 0
         }
       },
-      "required": [
-        "Form",
-        "SideLength",
-        "WallThickness"
-      ],
+      "required": ["Form", "SideLength", "WallThickness"],
       "additionalProperties": false
     },
     "RectangularPipe": {
+      "title": "RectangularPipe",
       "description": "",
       "type": "object",
       "properties": {
@@ -202,15 +191,11 @@
           "minimum": 0
         }
       },
-      "required": [
-        "Form",
-        "Width",
-        "Height",
-        "WallThickness"
-      ],
+      "required": ["Form", "Width", "Height", "WallThickness"],
       "additionalProperties": true
     },
     "Coil": {
+      "title": "Coil",
       "description": "",
       "type": "object",
       "properties": {
@@ -230,14 +215,11 @@
           "minimum": 0
         }
       },
-      "required": [
-        "Form",
-        "Width",
-        "WallThickness"
-      ],
+      "required": ["Form", "Width", "WallThickness"],
       "additionalProperties": true
     },
     "RoundBar": {
+      "title": "RoundBar",
       "description": "",
       "type": "object",
       "properties": {
@@ -252,13 +234,11 @@
           "minimum": 0
         }
       },
-      "required": [
-        "Form",
-        "Diameter"
-      ],
+      "required": ["Form", "Diameter"],
       "additionalProperties": false
     },
     "HexagonalBar": {
+      "title": "HexagonalBar",
       "description": "",
       "type": "object",
       "properties": {
@@ -273,13 +253,11 @@
           "minimum": 0
         }
       },
-      "required": [
-        "Form",
-        "Diameter"
-      ],
+      "required": ["Form", "Diameter"],
       "additionalProperties": false
     },
     "FlatBar": {
+      "title": "FlatBar",
       "description": "",
       "type": "object",
       "properties": {
@@ -299,14 +277,11 @@
           "minimum": 0
         }
       },
-      "required": [
-        "Form",
-        "Width",
-        "Thickness"
-      ],
+      "required": ["Form", "Width", "Thickness"],
       "additionalProperties": false
     },
     "Other": {
+      "title": "Other",
       "description": "",
       "type": "object",
       "properties": {
@@ -320,13 +295,11 @@
           "type": "string"
         }
       },
-      "required": [
-        "Form",
-        "Description"
-      ],
+      "required": ["Form", "Description"],
       "additionalProperties": false
     },
     "ProductDescription": {
+      "title": "ProductDescription",
       "oneOf": [
         {
           "$ref": "#/definitions/Tube"
@@ -361,6 +334,7 @@
       ]
     },
     "Company": {
+      "title": "Company",
       "type": "object",
       "properties": {
         "CompanyName": {
@@ -392,13 +366,7 @@
         "CertificateLanguage": {
           "type": "array",
           "items": {
-            "type": "string",
-            "enum": [
-              "EN",
-              "DE",
-              "FR",
-              "PL"
-            ]
+            "$ref": "#/definitions/Language"
           },
           "minItems": 1,
           "maxItems": 2,
@@ -423,6 +391,7 @@
       "additionalProperties": true
     },
     "CommercialTransaction": {
+      "title": "CommercialTransaction",
       "description": "",
       "type": "object",
       "properties": {
@@ -478,12 +447,10 @@
           "type": "string"
         },
         "SupplementaryInformation": {
+          "title": "CommercialTransactionSupplementaryInformation",
           "type": "object",
-          "propertyNames": {
-            "pattern": "A1[0-9]|A[2-8][0-9]|A[2-9][0-7]"
-          },
           "patternProperties": {
-            "": {
+            "A1[0-9]|A[2-8][0-9]|A[2-9][0-7]": {
               "$ref": "#/definitions/KeyValueObject"
             }
           },
@@ -505,6 +472,7 @@
       "additionalProperties": false
     },
     "Measurement": {
+      "title": "Measurement",
       "type": "object",
       "description": "Measured Values in a structured fashion for easy processing and rendering of data",
       "properties": {
@@ -529,20 +497,16 @@
           "type": "string"
         }
       },
-      "required": [
-        "Value"
-      ],
+      "required": ["Value"],
       "additionalProperties": false
     },
     "ChemicalComposition": {
+      "title": "ChemicalComposition",
       "type": "object",
       "properties": {
         "C70": {
           "description": "The metallurgic process, which is restricted to 2 types: Y = Basic oxygen process, E = Electric furnace",
-          "enum": [
-            "Y",
-            "E"
-          ]
+          "enum": ["Y", "E"]
         },
         "C71": {
           "description": "Share of element",
@@ -701,12 +665,10 @@
           "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
         },
         "SupplementaryInformation": {
+          "title": "ChemicalCompositionSupplementaryInformation",
           "type": "object",
-          "propertyNames": {
-            "pattern": "^C11[0-9]"
-          },
           "patternProperties": {
-            "": {
+            "C[7-9][0-9]|C[1][0][0-9]": {
               "$ref": "#/definitions/KeyValueObject"
             }
           },
@@ -716,6 +678,7 @@
       "additionalProperties": false
     },
     "CertificateProductDescription": {
+      "title": "CertificateProductDescription",
       "type": "object",
       "properties": {
         "B01": {
@@ -802,27 +765,21 @@
           "type": "number"
         },
         "SupplementaryInformation": {
+          "title": "CertificateProductDescriptionSupplementaryInformation",
           "type": "object",
-          "propertyNames": {
-            "pattern": "B1[4-9]|B[2-9][0-9]"
-          },
           "patternProperties": {
-            "": {
+            "B1[4-9]|B[2-9][0-9]": {
               "$ref": "#/definitions/KeyValueObject"
             }
           },
           "additionalProperties": false
         }
       },
-      "required": [
-        "B01",
-        "B02",
-        "B07",
-        "B08"
-      ],
+      "required": ["B01", "B02", "B07", "B08"],
       "additionalProperties": false
     },
     "Inspection": {
+      "title": "Inspection",
       "type": "object",
       "properties": {
         "C00": {
@@ -842,18 +799,17 @@
           "type": "string"
         },
         "SupplementaryInformation": {
+          "title": "InspectionSupplementaryInformation",
           "type": "object",
-          "propertyNames": {
-            "pattern": "^C0[4-9]"
-          },
           "patternProperties": {
-            "": {
+            "^C0[4-9]": {
               "$ref": "#/definitions/KeyValueObject"
             }
           },
           "additionalProperties": false
         },
         "TensileTest": {
+          "title": "TensileTest",
           "type": "object",
           "properties": {
             "C10": {
@@ -873,12 +829,10 @@
               "allOf": [{ "$ref": "#/definitions/Measurement" }]
             },
             "SupplementaryInformation": {
+              "title": "TensileTestSupplementaryInformation",
               "type": "object",
-              "propertyNames": {
-                "pattern": "^C1[4-9]|C2[0-9]"
-              },
               "patternProperties": {
-                "": {
+                "^C1[4-9]|C2[0-9]": {
                   "$ref": "#/definitions/KeyValueObject"
                 }
               }
@@ -886,6 +840,7 @@
           }
         },
         "HardnessTest": {
+          "title": "HardnessTest",
           "type": "object",
           "properties": {
             "C30": {
@@ -904,12 +859,10 @@
               "allOf": [{ "$ref": "#/definitions/Measurement" }]
             },
             "SupplementaryInformation": {
+              "title": "HardnessTestSupplementaryInformation",
               "type": "object",
-              "propertyNames": {
-                "pattern": "^C3[3-9]"
-              },
               "patternProperties": {
-                "": {
+                "^C3[3-9]": {
                   "$ref": "#/definitions/KeyValueObject"
                 }
               }
@@ -917,6 +870,7 @@
           }
         },
         "NotchedBarImpactTest": {
+          "title": "NotchedBarImpactTest",
           "type": "object",
           "properties": {
             "C40": {
@@ -939,12 +893,10 @@
               "allOf": [{ "$ref": "#/definitions/Measurement" }]
             },
             "SupplementaryInformation": {
+              "title": "NotchedBarImpactTestSupplementaryInformation",
               "type": "object",
-              "propertyNames": {
-                "pattern": "^C4[4-9]"
-              },
               "patternProperties": {
-                "": {
+                "^C4[4-9]": {
                   "$ref": "#/definitions/KeyValueObject"
                 }
               }
@@ -952,12 +904,10 @@
           }
         },
         "OtherMechanicalTests": {
+          "title": "OtherMechanicalTests",
           "type": "object",
-          "propertyNames": {
-            "pattern": "^C[5-6][0-9]"
-          },
           "patternProperties": {
-            "": {
+            "^C[5-6][0-9]": {
               "$ref": "#/definitions/KeyValueObject"
             }
           }
@@ -966,13 +916,11 @@
           "$ref": "#/definitions/ChemicalComposition"
         }
       },
-      "required": [
-        "C00",
-        "ChemicalComposition"
-      ],
+      "required": ["C00", "ChemicalComposition"],
       "additionalProperties": false
     },
     "Validation": {
+      "title": "Validation",
       "type": "object",
       "properties": {
         "Z01": {
@@ -1011,30 +959,19 @@
               "type": "string"
             }
           },
-          "required": [
-            "CE_Image",
-            "NotifiedBodyNumber",
-            "DoCYear",
-            "DoCNumber"
-          ]
+          "required": ["CE_Image", "NotifiedBodyNumber", "DoCYear", "DoCNumber"]
         },
         "SupplementaryInformation": {
+          "title": "ValidationSupplementaryInformation",
           "type": "object",
-          "propertyNames": {
-            "pattern": "Z0[5-9]|Z[1-9][0-9]"
-          },
           "patternProperties": {
-            "": {
+            "Z0[5-9]|Z[1-9][0-9]": {
               "$ref": "#/definitions/KeyValueObject"
             }
           }
         }
       },
-      "required": [
-        "Z01",
-        "Z02",
-        "Z04"
-      ],
+      "required": ["Z01", "Z02", "Z04"],
       "additionalProperties": false
     }
   },
@@ -1042,6 +979,7 @@
   "type": "object",
   "properties": {
     "metadata": {
+      "title": "metadata",
       "description": "",
       "type": "object",
       "properties": {
@@ -1057,16 +995,10 @@
         "state": {
           "description": "",
           "type": "string",
-          "enum": [
-            "draft",
-            "valid",
-            "cancelled"
-          ]
+          "enum": ["draft", "valid", "cancelled"]
         }
       },
-      "required": [
-        "id"
-      ]
+      "required": ["id"]
     },
     "Certificate": {
       "description": "",
@@ -1089,6 +1021,7 @@
           "$ref": "#/definitions/Inspection"
         },
         "OtherTests": {
+          "title": "OtherTests",
           "type": "object",
           "properties": {
             "D01": {
@@ -1096,24 +1029,20 @@
               "type": "string"
             },
             "NonDestructiveTests": {
+              "title": "NonDestructiveTests",
               "type": "object",
-              "propertyNames": {
-                "pattern": "^D[0][2-9]|^D[1-4]D[0-9]"
-              },
               "patternProperties": {
-                "": {
+                "^D[0][2-9]|^D[1-4]D[0-9]": {
                   "$ref": "#/definitions/KeyValueObject"
                 }
               },
               "additionalProperties": false
             },
             "SupplementaryInformation": {
+              "title": "OtherTestsSupplementaryInformation",
               "type": "object",
-              "propertyNames": {
-                "pattern": "^D[5-9][0-9]"
-              },
               "patternProperties": {
-                "": {
+                "^D[5-9][0-9]": {
                   "$ref": "#/definitions/KeyValueObject"
                 }
               },

--- a/EN10168-v1.0.schema.json
+++ b/EN10168-v1.0.schema.json
@@ -69,7 +69,8 @@
       "properties": {
         "Form": {
           "description": "",
-          "const": "Tube"
+          "const": "Tube",
+          "default": "Tube"
         },
         "OuterDiameter": {
           "description": "",
@@ -95,7 +96,8 @@
       "properties": {
         "Form": {
           "description": "",
-          "const": "QuadraticTube"
+          "const": "QuadraticTube",
+          "default": "QuadraticTube"
         },
         "SideLength": {
           "description": "",
@@ -121,7 +123,8 @@
       "properties": {
         "Form": {
           "description": "",
-          "const": "RectangularTube"
+          "const": "RectangularTube",
+          "default": "RectangularTube"
         },
         "Width": {
           "description": "",
@@ -153,7 +156,8 @@
       "properties": {
         "Form": {
           "description": "",
-          "const": "Pipe"
+          "const": "Pipe",
+          "default": "Pipe"
         },
         "SideLength": {
           "description": "",
@@ -179,7 +183,8 @@
       "properties": {
         "Form": {
           "description": "",
-          "const": "RectangularPipe"
+          "const": "RectangularPipe",
+          "default": "RectangularPipe"
         },
         "Width": {
           "description": "",
@@ -211,7 +216,8 @@
       "properties": {
         "Form": {
           "description": "",
-          "const": "Coil"
+          "const": "Coil",
+          "default": "Coil"
         },
         "Width": {
           "description": "",
@@ -237,7 +243,8 @@
       "properties": {
         "Form": {
           "description": "",
-          "const": "RoundBar"
+          "const": "RoundBar",
+          "default": "RoundBar"
         },
         "Diameter": {
           "description": "",
@@ -257,7 +264,8 @@
       "properties": {
         "Form": {
           "description": "",
-          "const": "RoundBar"
+          "const": "HexagonalBar",
+          "default": "HexagonalBar"
         },
         "Diameter": {
           "description": "",
@@ -277,7 +285,8 @@
       "properties": {
         "Form": {
           "description": "",
-          "const": "FlatBar"
+          "const": "FlatBar",
+          "default": "FlatBar"
         },
         "Width": {
           "description": "",
@@ -303,7 +312,8 @@
       "properties": {
         "Form": {
           "description": "",
-          "const": "Other"
+          "const": "Other",
+          "default": "Other"
         },
         "Description": {
           "description": "",
@@ -317,46 +327,35 @@
       "additionalProperties": false
     },
     "ProductDescription": {
-      "type": "object",
       "oneOf": [
         {
-          "description": "",
           "$ref": "#/definitions/Tube"
         },
         {
-          "description": "",
           "$ref": "#/definitions/RectangularTube"
         },
         {
-          "description": "",
           "$ref": "#/definitions/QuadraticTube"
         },
         {
-          "description": "",
           "$ref": "#/definitions/Pipe"
         },
         {
-          "description": "",
           "$ref": "#/definitions/RectangularPipe"
         },
         {
-          "description": "",
           "$ref": "#/definitions/Coil"
         },
         {
-          "description": "",
           "$ref": "#/definitions/RoundBar"
         },
         {
-          "description": "",
           "$ref": "#/definitions/HexagonalBar"
         },
         {
-          "description": "",
           "$ref": "#/definitions/FlatBar"
         },
         {
-          "description": "",
           "$ref": "#/definitions/Other"
         }
       ]
@@ -423,6 +422,88 @@
       ],
       "additionalProperties": true
     },
+    "CommercialTransaction": {
+      "description": "",
+      "type": "object",
+      "properties": {
+        "A01": {
+          "allOf": [{ "$ref": "#/definitions/Company" }],
+          "description": "The manufacturer's works which delivers the certificate along the product"
+        },
+        "A02": {
+          "description": "The type of inspection document, e.g. 'EN 10204 3.1 Certificate'",
+          "type": "string"
+        },
+        "A03": {
+          "description": "The document number of the certifcate",
+          "type": "string"
+        },
+        "A04": {
+          "description": "The mark of the manufacturer as base64 png file. The maximum size is <TBD>",
+          "type": "string",
+          "contentEncoding": "base64",
+          "contentMediaType": "image/png"
+        },
+        "A05": {
+          "description": "The originator of the document, not necessarily equal to A01",
+          "type": "string",
+          "default": "Factory Production Control"
+        },
+        "A06": {
+          "allOf": [{ "$ref": "#/definitions/Company" }],
+          "description": "The purchaser of the product and receiver of the certificate"
+        },
+        "A06.1": {
+          "allOf": [{ "$ref": "#/definitions/Company" }],
+          "description": "The purchaser of the product"
+        },
+        "A06.2": {
+          "allOf": [{ "$ref": "#/definitions/Company" }],
+          "description": "The consignee of the product"
+        },
+        "A06.3": {
+          "allOf": [{ "$ref": "#/definitions/Company" }],
+          "description": "The receiver/consignee of the certificate"
+        },
+        "A07": {
+          "description": "Purchase number",
+          "type": "string"
+        },
+        "A08": {
+          "description": "Manufacturer's work number",
+          "type": "string"
+        },
+        "A09": {
+          "description": "The article number used by the purchaser",
+          "type": "string"
+        },
+        "SupplementaryInformation": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "A1[0-9]|A[2-8][0-9]|A[2-9][0-7]"
+          },
+          "patternProperties": {
+            "": {
+              "$ref": "#/definitions/KeyValueObject"
+            }
+          },
+          "additionalProperties": false
+        },
+        "A97": {
+          "description": "The position number in the order",
+          "type": "number"
+        },
+        "A98": {
+          "description": "A custom field for the delivery note number",
+          "type": "string"
+        },
+        "A99": {
+          "description": "A custom field for the aviso document number",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "Measurement": {
       "type": "object",
       "description": "Measured Values in a structured fashion for easy processing and rendering of data",
@@ -450,6 +531,509 @@
       },
       "required": [
         "Value"
+      ],
+      "additionalProperties": false
+    },
+    "ChemicalComposition": {
+      "type": "object",
+      "properties": {
+        "C70": {
+          "description": "The metallurgic process, which is restricted to 2 types: Y = Basic oxygen process, E = Electric furnace",
+          "enum": [
+            "Y",
+            "E"
+          ]
+        },
+        "C71": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C72": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C73": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C74": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C75": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C76": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C77": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C78": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C79": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C80": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C81": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C82": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C83": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C84": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C85": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C86": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C87": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C88": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C89": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C90": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C91": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C92": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C93": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C94": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C95": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C96": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C97": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C98": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C99": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C100": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C101": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C102": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C103": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C104": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C105": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C106": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C107": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C108": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "C109": {
+          "description": "Share of element",
+          "allOf": [{ "$ref": "#/definitions/ChemicalElement" }]
+        },
+        "SupplementaryInformation": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^C11[0-9]"
+          },
+          "patternProperties": {
+            "": {
+              "$ref": "#/definitions/KeyValueObject"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "CertificateProductDescription": {
+      "type": "object",
+      "properties": {
+        "B01": {
+          "description": "The product",
+          "type": "string"
+        },
+        "B02": {
+          "description": "",
+          "type": "object",
+          "properties": {
+            "ProductNorm": {
+              "description": "The product norm designation",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "MaterialNorm": {
+              "description": "The material norm(s)",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "MassNorm": {
+              "description": "The mass norm(s)",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "SteelDesignation": {
+              "description": "The steel designation(s)",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "B03": {
+          "description": "Any supplemantary requirements",
+          "type": "string"
+        },
+        "B04": {
+          "description": "The delivery conditions for the product",
+          "type": "string"
+        },
+        "B05": {
+          "description": "Reference heat treatment of samples",
+          "type": "string"
+        },
+        "B06": {
+          "description": "Marking of the product",
+          "type": "string"
+        },
+        "B07": {
+          "description": "Identification of the product, usually batch, charge or lot number",
+          "type": "string"
+        },
+        "B08": {
+          "description": "Number of pieces of the product.",
+          "type": "number"
+        },
+        "B09": {
+          "allOf": [{ "$ref": "#/definitions/ProductDescription" }],
+          "description": "Product type and its describing dimensional parameters"
+        },
+        "B10": {
+          "description": "Product dimensions - length of the product",
+          "type": "number"
+        },
+        "B11": {
+          "description": "Product dimensions ",
+          "type": "number"
+        },
+        "B12": {
+          "description": "Theoretical mass",
+          "type": "number"
+        },
+        "B13": {
+          "description": "Actual mass",
+          "type": "number"
+        },
+        "SupplementaryInformation": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "B1[4-9]|B[2-9][0-9]"
+          },
+          "patternProperties": {
+            "": {
+              "$ref": "#/definitions/KeyValueObject"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "B01",
+        "B02",
+        "B07",
+        "B08"
+      ],
+      "additionalProperties": false
+    },
+    "Inspection": {
+      "type": "object",
+      "properties": {
+        "C00": {
+          "description": "Heat or melt number defining the chemical properties",
+          "type": "string"
+        },
+        "C01": {
+          "description": "Location of the sample",
+          "type": "string"
+        },
+        "C02": {
+          "description": "Direction of the test pieces",
+          "type": "string"
+        },
+        "C03": {
+          "description": "Test temperature",
+          "type": "string"
+        },
+        "SupplementaryInformation": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^C0[4-9]"
+          },
+          "patternProperties": {
+            "": {
+              "$ref": "#/definitions/KeyValueObject"
+            }
+          },
+          "additionalProperties": false
+        },
+        "TensileTest": {
+          "type": "object",
+          "properties": {
+            "C10": {
+              "description": "Shape of the test piece",
+              "type": "string"
+            },
+            "C11": {
+              "description": "Yield or proof strength",
+              "allOf": [{ "$ref": "#/definitions/Measurement" }]
+            },
+            "C12": {
+              "description": "Tensile strength",
+              "allOf": [{ "$ref": "#/definitions/Measurement" }]
+            },
+            "C13": {
+              "description": "Elongation after fracture",
+              "allOf": [{ "$ref": "#/definitions/Measurement" }]
+            },
+            "SupplementaryInformation": {
+              "type": "object",
+              "propertyNames": {
+                "pattern": "^C1[4-9]|C2[0-9]"
+              },
+              "patternProperties": {
+                "": {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              }
+            }
+          }
+        },
+        "HardnessTest": {
+          "type": "object",
+          "properties": {
+            "C30": {
+              "description": "Method of test",
+              "type": "string"
+            },
+            "C31": {
+              "description": "The individual values measured",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Measurement"
+              }
+            },
+            "C32": {
+              "description": "The average value of the individual values measured",
+              "allOf": [{ "$ref": "#/definitions/Measurement" }]
+            },
+            "SupplementaryInformation": {
+              "type": "object",
+              "propertyNames": {
+                "pattern": "^C3[3-9]"
+              },
+              "patternProperties": {
+                "": {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              }
+            }
+          }
+        },
+        "NotchedBarImpactTest": {
+          "type": "object",
+          "properties": {
+            "C40": {
+              "description": "Type of test piece",
+              "type": "string"
+            },
+            "C41": {
+              "description": "Width of test piece",
+              "type": "string"
+            },
+            "C42": {
+              "description": "Individual values",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Measurement"
+              }
+            },
+            "C43": {
+              "description": "Mean value",
+              "allOf": [{ "$ref": "#/definitions/Measurement" }]
+            },
+            "SupplementaryInformation": {
+              "type": "object",
+              "propertyNames": {
+                "pattern": "^C4[4-9]"
+              },
+              "patternProperties": {
+                "": {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              }
+            }
+          }
+        },
+        "OtherMechanicalTests": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^C[5-6][0-9]"
+          },
+          "patternProperties": {
+            "": {
+              "$ref": "#/definitions/KeyValueObject"
+            }
+          }
+        },
+        "ChemicalComposition": {
+          "$ref": "#/definitions/ChemicalComposition"
+        }
+      },
+      "required": [
+        "C00",
+        "ChemicalComposition"
+      ],
+      "additionalProperties": false
+    },
+    "Validation": {
+      "type": "object",
+      "properties": {
+        "Z01": {
+          "description": "Statement of compliance",
+          "type": "string"
+        },
+        "Z02": {
+          "description": "Date of issue and validation",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Z03": {
+          "description": "Stamp of the inspection representative",
+          "type": "string"
+        },
+        "Z04": {
+          "description": "CE marking",
+          "type": "object",
+          "properties": {
+            "CE_Image": {
+              "description": "The CE image as base64 encoded png file. A default with size 90x65 is provided by example",
+              "type": "string",
+              "contentEncoding": "base64",
+              "contentMediaType": "image/png"
+            },
+            "NotifiedBodyNumber": {
+              "description": "The identification number of the Notified body. Refer to https://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:31993L0068:en:HTML and https://ec.europa.eu/growth/tools-databases/nando/index.cfm?fuseaction=notifiedbody.main",
+              "type": "string"
+            },
+            "DoCYear": {
+              "description": "The year when the declaration of conformance was issued",
+              "type": "string"
+            },
+            "DoCNumber": {
+              "description": "The declaration of conformance document number ",
+              "type": "string"
+            }
+          },
+          "required": [
+            "CE_Image",
+            "NotifiedBodyNumber",
+            "DoCYear",
+            "DoCNumber"
+          ]
+        },
+        "SupplementaryInformation": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "Z0[5-9]|Z[1-9][0-9]"
+          },
+          "patternProperties": {
+            "": {
+              "$ref": "#/definitions/KeyValueObject"
+            }
+          }
+        }
+      },
+      "required": [
+        "Z01",
+        "Z02",
+        "Z04"
       ],
       "additionalProperties": false
     }
@@ -496,521 +1080,13 @@
       ],
       "properties": {
         "CommercialTransaction": {
-          "description": "",
-          "type": "object",
-          "properties": {
-            "A01": {
-              "description": "The manufacturer's works which delivers the certificate along the product",
-              "$ref": "#/definitions/Company"
-            },
-            "A02": {
-              "description": "The type of inspection document, e.g. 'EN 10204 3.1 Certificate'",
-              "type": "string"
-            },
-            "A03": {
-              "description": "The document number of the certifcate",
-              "type": "string"
-            },
-            "A04": {
-              "description": "The mark of the manufacturer as base64 png file. The maximum size is <TBD>",
-              "type": "string",
-              "contentEncoding": "base64",
-              "contentMediaType": "image/png"
-            },
-            "A05": {
-              "description": "The originator of the document, not necessarily equal to A01",
-              "type": "string",
-              "default": "Factory Production Control"
-            },
-            "A06": {
-              "description": "The purchaser of the product and receiver of the certificate",
-              "$ref": "#/definitions/Company"
-            },
-            "A06.1": {
-              "description": "The purchaser of the product",
-              "$ref": "#/definitions/Company"
-            },
-            "A06.2": {
-              "description": "The consignee of the product",
-              "$ref": "#/definitions/Company"
-            },
-            "A06.3": {
-              "description": "The receiver/consignee of the certificate",
-              "$ref": "#/definitions/Company"
-            },
-            "A07": {
-              "description": "Purchase number",
-              "type": "string"
-            },
-            "A08": {
-              "description": "Manufacturer's work number",
-              "type": "string"
-            },
-            "A09": {
-              "description": "The article number used by the purchaser",
-              "type": "string"
-            },
-            "SupplementaryInformation": {
-              "type": "object",
-              "propertyNames": {
-                "pattern": "A1[0-9]|A[2-8][0-9]|A[2-9][0-7]"
-              },
-              "patternProperties": {
-                "": {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              },
-              "additionalProperties": false
-            },
-            "A97": {
-              "description": "The position number in the order",
-              "type": "number"
-            },
-            "A98": {
-              "description": "A custom field for the delivery note number",
-              "type": "string"
-            },
-            "A99": {
-              "description": "A custom field for the aviso document number",
-              "type": "string"
-            },
-            "additionalProperties": false
-          },
-          "additionalProperties": false
+          "$ref": "#/definitions/CommercialTransaction"
         },
         "ProductDescription": {
-          "type": "object",
-          "properties": {
-            "B01": {
-              "description": "The product",
-              "type": "string"
-            },
-            "B02": {
-              "description": "",
-              "type": "object",
-              "properties": {
-                "ProductNorm": {
-                  "description": "The product norm designation",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "MaterialNorm": {
-                  "description": "The material norm(s)",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "MassNorm": {
-                  "description": "The mass norm(s)",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "SteelDesignation": {
-                  "description": "The steel designation(s)",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "B03": {
-              "description": "Any supplemantary requirements",
-              "type": "string"
-            },
-            "B04": {
-              "description": "The delivery conditions for the product",
-              "type": "string"
-            },
-            "B05": {
-              "description": "Reference heat treatment of samples",
-              "type": "string"
-            },
-            "B06": {
-              "description": "Marking of the product",
-              "type": "string"
-            },
-            "B07": {
-              "description": "Identification of the product, usually batch, charge or lot number",
-              "type": "string"
-            },
-            "B08": {
-              "description": "Number of pieces of the product.",
-              "type": "number"
-            },
-            "B09": {
-              "description": "Product type and its describing dimensional parameters",
-              "$ref": "#/definitions/ProductDescription"
-            },
-            "B10": {
-              "description": "Product dimensions - length of the product",
-              "type": "number"
-            },
-            "B11": {
-              "description": "Product dimensions ",
-              "type": "number"
-            },
-            "B12": {
-              "description": "Theoretical mass",
-              "type": "number"
-            },
-            "B13": {
-              "description": "Actual mass",
-              "type": "number"
-            },
-            "SupplementaryInformation": {
-              "type": "object",
-              "propertyNames": {
-                "pattern": "B1[4-9]|B[2-9][0-9]"
-              },
-              "patternProperties": {
-                "": {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          "required": [
-            "B01",
-            "B02",
-            "B07",
-            "B08"
-          ],
-          "additionalProperties": false
+          "$ref": "#/definitions/CertificateProductDescription"
         },
         "Inspection": {
-          "type": "object",
-          "properties": {
-            "C00": {
-              "description": "Heat or melt number defining the chemical properties",
-              "type": "string"
-            },
-            "C01": {
-              "description": "Location of the sample",
-              "type": "string"
-            },
-            "C02": {
-              "description": "Direction of the test pieces",
-              "type": "string"
-            },
-            "C03": {
-              "description": "Test temperature",
-              "type": "string"
-            },
-            "SupplementaryInformation": {
-              "type": "object",
-              "propertyNames": {
-                "pattern": "^C0[4-9]"
-              },
-              "patternProperties": {
-                "": {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              }
-            },
-            "TensileTest": {
-              "type": "object",
-              "properties": {
-                "C10": {
-                  "description": "Shape of the test piece",
-                  "type": "string"
-                },
-                "C11": {
-                  "description": "Yield or proof strength",
-                  "$ref": "#/definitions/Measurement"
-                },
-                "C12": {
-                  "description": "Tensile strength",
-                  "$ref": "#/definitions/Measurement"
-                },
-                "C13": {
-                  "description": "Elongation after fracture",
-                  "$ref": "#/definitions/Measurement"
-                },
-                "SupplementaryInformation": {
-                  "type": "object",
-                  "propertyNames": {
-                    "pattern": "^C1[4-9]|C2[0-9]"
-                  },
-                  "patternProperties": {
-                    "": {
-                      "$ref": "#/definitions/KeyValueObject"
-                    }
-                  }
-                }
-              }
-            },
-            "HardnessTest": {
-              "type": "object",
-              "properties": {
-                "C30": {
-                  "description": "Method of test",
-                  "type": "string"
-                },
-                "C31": {
-                  "description": "The individual values measured",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/Measurement"
-                  }
-                },
-                "C32": {
-                  "description": "The average value of the individual values measured",
-                  "$ref": "#/definitions/Measurement"
-                },
-                "SupplementaryInformation": {
-                  "type": "object",
-                  "propertyNames": {
-                    "pattern": "^C3[3-9]"
-                  },
-                  "patternProperties": {
-                    "": {
-                      "$ref": "#/definitions/KeyValueObject"
-                    }
-                  }
-                }
-              }
-            },
-            "NotchedBarImpactTest": {
-              "type": "object",
-              "properties": {
-                "C40": {
-                  "description": "Type of test piece",
-                  "type": "string"
-                },
-                "C41": {
-                  "description": "Width of test piece",
-                  "type": "string"
-                },
-                "C42": {
-                  "description": "Individual values",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/Measurement"
-                  }
-                },
-                "C43": {
-                  "description": "Mean value",
-                  "$ref": "#/definitions/Measurement"
-                },
-                "SupplementaryInformation": {
-                  "type": "object",
-                  "propertyNames": {
-                    "pattern": "^C4[4-9]"
-                  },
-                  "patternProperties": {
-                    "": {
-                      "$ref": "#/definitions/KeyValueObject"
-                    }
-                  }
-                }
-              }
-            },
-            "OtherMechanicalTests": {
-              "type": "object",
-              "propertyNames": {
-                "pattern": "^C[5-6][0-9]"
-              },
-              "patternProperties": {
-                "": {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              }
-            },
-            "ChemicalComposition": {
-              "type": "object",
-              "properties": {
-                "C70": {
-                  "description": "The metallurgic process, which is restricted to 2 types: Y = Basic oxygen process, E = Electric furnace",
-                  "enum": [
-                    "Y",
-                    "E"
-                  ]
-                },
-                "C71": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C72": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C73": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C74": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C75": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C76": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C77": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C78": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C79": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C80": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C81": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C82": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C83": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C84": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C85": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C86": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C87": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C88": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C89": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C90": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C91": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C92": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C93": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C94": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C95": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C96": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C97": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C98": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C99": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C100": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C101": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C102": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C103": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C104": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C105": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C106": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C107": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C108": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "C109": {
-                  "description": "Share of element",
-                  "$ref": "#/definitions/ChemicalElement"
-                },
-                "SupplementaryInformation": {
-                  "type": "object",
-                  "propertyNames": {
-                    "pattern": "^C11[0-9]"
-                  },
-                  "patternProperties": {
-                    "": {
-                      "$ref": "#/definitions/KeyValueObject"
-                    }
-                  }
-                },
-                "additionalProperties": false
-              },
-              "additionalProperties": false
-            }
-          },
-          "required": [
-            "C00",
-            "ChemicalComposition"
-          ],
-          "additionalProperties": false
+          "$ref": "#/definitions/Inspection"
         },
         "OtherTests": {
           "type": "object",
@@ -1042,74 +1118,12 @@
                 }
               },
               "additionalProperties": false
-            },
-            "additionalProperties": false
-          }
-        },
-        "Validation": {
-          "type": "object",
-          "properties": {
-            "Z01": {
-              "description": "Statement of compliance",
-              "type": "string"
-            },
-            "Z02": {
-              "description": "Date of issue and validation",
-              "type": "string",
-              "format": "date-time"
-            },
-            "Z03": {
-              "description": "Stamp of the inspection representative",
-              "type": "string"
-            },
-            "Z04": {
-              "description": "CE marking",
-              "type": "object",
-              "properties": {
-                "CE_Image": {
-                  "description": "The CE image as base64 encoded png file. A default with size 90x65 is provided by example",
-                  "type": "string",
-                  "contentEncoding": "base64",
-                  "contentMediaType": "image/png"
-                },
-                "NotifiedBodyNumber": {
-                  "description": "The identification number of the Notified body. Refer to https://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:31993L0068:en:HTML and https://ec.europa.eu/growth/tools-databases/nando/index.cfm?fuseaction=notifiedbody.main",
-                  "type": "string"
-                },
-                "DoCYear": {
-                  "description": "The year when the declaration of conformance was issued",
-                  "type": "string"
-                },
-                "DoCNumber": {
-                  "description": "The declaration of conformance document number ",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "CE_Image",
-                "NotifiedBodyNumber",
-                "DoCYear",
-                "DoCNumber"
-              ]
-            },
-            "SupplementaryInformation": {
-              "type": "object",
-              "propertyNames": {
-                "pattern": "Z0[5-9]|Z[1-9][0-9]"
-              },
-              "patternProperties": {
-                "": {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              }
             }
           },
-          "required": [
-            "Z01",
-            "Z02",
-            "Z04"
-          ],
           "additionalProperties": false
+        },
+        "Validation": {
+          "$ref": "#/definitions/Validation"
         }
       }
     }

--- a/EN10168-v1.0.schema.json
+++ b/EN10168-v1.0.schema.json
@@ -28,22 +28,6 @@
       "required": ["Key"],
       "additionalProperties": false
     },
-    "SupplementaryInformation": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        },
-        "unit": {
-          "type": "string"
-        }
-      },
-      "required": ["key", "value"],
-      "additionalProperties": false
-    },
     "Language": {
       "title": "Language",
       "type": "string",
@@ -470,14 +454,7 @@
           },
           "patternProperties": {
             "A1[0-9]|A[2-8][0-9]|A[2-9][0-7]": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/SupplementaryInformation"
-                },
-                {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              ]
+              "$ref": "#/definitions/KeyValueObject"
             }
           },
           "additionalProperties": true
@@ -698,14 +675,7 @@
           },
           "patternProperties": {
             "": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/SupplementaryInformation"
-                },
-                {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              ]
+              "$ref": "#/definitions/KeyValueObject"
             }
           },
           "additionalProperties": true
@@ -808,14 +778,7 @@
           },
           "patternProperties": {
             "^B1[4-9]|^B[2-9][0-9]": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/SupplementaryInformation"
-                },
-                {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              ]
+              "$ref": "#/definitions/KeyValueObject"
             }
           },
           "additionalProperties": false
@@ -840,14 +803,7 @@
               "pattern": "^D[0][2-9]|^D[1-4]D[0-9]"
             },
             "^D[0][2-9]|^D[1-4]D[0-9]": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/SupplementaryInformation"
-                },
-                {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              ]
+              "$ref": "#/definitions/KeyValueObject"
             }
           },
           "additionalProperties": false
@@ -860,14 +816,7 @@
           },
           "patternProperties": {
             "^D[5-9][0-9]": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/SupplementaryInformation"
-                },
-                {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              ]
+              "$ref": "#/definitions/KeyValueObject"
             }
           },
           "additionalProperties": false
@@ -903,14 +852,7 @@
           },
           "patternProperties": {
             "^C0[4-9]": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/SupplementaryInformation"
-                },
-                {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              ]
+              "$ref": "#/definitions/KeyValueObject"
             }
           },
           "additionalProperties": false
@@ -943,14 +885,7 @@
               },
               "patternProperties": {
                 "^C1[4-9]|^C2[0-9]": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/SupplementaryInformation"
-                    },
-                    {
-                      "$ref": "#/definitions/KeyValueObject"
-                    }
-                  ]
+                  "$ref": "#/definitions/KeyValueObject"
                 }
               }
             }
@@ -983,14 +918,7 @@
               },
               "patternProperties": {
                 "^C3[3-9]": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/SupplementaryInformation"
-                    },
-                    {
-                      "$ref": "#/definitions/KeyValueObject"
-                    }
-                  ]
+                  "$ref": "#/definitions/KeyValueObject"
                 }
               }
             }
@@ -1027,14 +955,7 @@
               },
               "patternProperties": {
                 "^C4[4-9]": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/SupplementaryInformation"
-                    },
-                    {
-                      "$ref": "#/definitions/KeyValueObject"
-                    }
-                  ]
+                  "$ref": "#/definitions/KeyValueObject"
                 }
               }
             }
@@ -1048,14 +969,7 @@
           },
           "patternProperties": {
             "^C[5-6][0-9]": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/SupplementaryInformation"
-                },
-                {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              ]
+              "$ref": "#/definitions/KeyValueObject"
             }
           }
         },
@@ -1119,14 +1033,7 @@
           },
           "patternProperties": {
             "^Z0[5-9]|^Z[1-9][0-9]": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/SupplementaryInformation"
-                },
-                {
-                  "$ref": "#/definitions/KeyValueObject"
-                }
-              ]
+              "$ref": "#/definitions/KeyValueObject"
             }
           }
         }

--- a/EN10168-v1.0.schema.json
+++ b/EN10168-v1.0.schema.json
@@ -694,10 +694,10 @@
           "title": "ChemicalCompositionSupplementaryInformation",
           "type": "object",
           "propertyNames": {
-            "pattern": "^C[7-9][0-9]|^C[1][0][0-9]"
+            "pattern": "^C[7-9][0-9]|^C[1][0-1][0-9]"
           },
           "patternProperties": {
-            "C[7-9][0-9]|C[1][0][0-9]": {
+            "": {
               "oneOf": [
                 {
                   "$ref": "#/definitions/SupplementaryInformation"
@@ -822,6 +822,57 @@
         }
       },
       "required": ["B01", "B02", "B07", "B08"],
+      "additionalProperties": false
+    },
+    "OtherTests": {
+      "title": "OtherTests",
+      "type": "object",
+      "properties": {
+        "D01": {
+          "description": "Marking and identification, surface appearance, shape and dimensional properties",
+          "type": "string"
+        },
+        "NonDestructiveTests": {
+          "title": "NonDestructiveTests",
+          "type": "object",
+          "patternProperties": {
+            "propertyNames": {
+              "pattern": "^D[0][2-9]|^D[1-4]D[0-9]"
+            },
+            "^D[0][2-9]|^D[1-4]D[0-9]": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/SupplementaryInformation"
+                },
+                {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "SupplementaryInformation": {
+          "title": "OtherTestsSupplementaryInformation",
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^D[5-9][0-9]"
+          },
+          "patternProperties": {
+            "^D[5-9][0-9]": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/SupplementaryInformation"
+                },
+                {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
       "additionalProperties": false
     },
     "Inspection": {
@@ -1010,6 +1061,9 @@
         },
         "ChemicalComposition": {
           "$ref": "#/definitions/ChemicalComposition"
+        },
+        "OtherTests": {
+          "$ref": "#/definitions/OtherTests"
         }
       },
       "required": ["C00", "ChemicalComposition"],
@@ -1112,7 +1166,7 @@
       "required": [
         "CommercialTransaction",
         "ProductDescription",
-        "Inspection",
+        "Inspections",
         "OtherTests",
         "Validation"
       ],
@@ -1123,64 +1177,27 @@
         "ProductDescription": {
           "$ref": "#/definitions/ProductDescription"
         },
-        "Inspection": {
-          "$ref": "#/definitions/Inspection"
+        "Inspections": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "Inspection": {
+                "$ref": "#/definitions/Inspection"
+              }
+            }
+          }
         },
         "OtherTests": {
-          "title": "OtherTests",
-          "type": "object",
-          "properties": {
-            "D01": {
-              "description": "Marking and identification, surface appearance, shape and dimensional properties",
-              "type": "string"
-            },
-            "NonDestructiveTests": {
-              "title": "NonDestructiveTests",
-              "type": "object",
-              "patternProperties": {
-                "propertyNames": {
-                  "pattern": "^D[0][2-9]|^D[1-4]D[0-9]"
-                },
-                "^D[0][2-9]|^D[1-4]D[0-9]": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/SupplementaryInformation"
-                    },
-                    {
-                      "$ref": "#/definitions/KeyValueObject"
-                    }
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
-            "SupplementaryInformation": {
-              "title": "OtherTestsSupplementaryInformation",
-              "type": "object",
-              "propertyNames": {
-                "pattern": "^D[5-9][0-9]"
-              },
-              "patternProperties": {
-                "^D[5-9][0-9]": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/SupplementaryInformation"
-                    },
-                    {
-                      "$ref": "#/definitions/KeyValueObject"
-                    }
-                  ]
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/definitions/OtherTests"
         },
         "Validation": {
           "$ref": "#/definitions/Validation"
         }
       }
     }
-  }
+  },
+  "required": ["Certificate"],
+  "additionalProperties": false
 }

--- a/EN10168-v1.0.schema.json
+++ b/EN10168-v1.0.schema.json
@@ -975,9 +975,6 @@
         },
         "ChemicalComposition": {
           "$ref": "#/definitions/ChemicalComposition"
-        },
-        "OtherTests": {
-          "$ref": "#/definitions/OtherTests"
         }
       },
       "required": ["C00", "ChemicalComposition"],
@@ -1073,7 +1070,7 @@
       "required": [
         "CommercialTransaction",
         "ProductDescription",
-        "Inspections",
+        "Inspection",
         "OtherTests",
         "Validation"
       ],
@@ -1084,17 +1081,8 @@
         "ProductDescription": {
           "$ref": "#/definitions/ProductDescription"
         },
-        "Inspections": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "properties": {
-              "Inspection": {
-                "$ref": "#/definitions/Inspection"
-              }
-            }
-          }
+        "Inspection": {
+          "$ref": "#/definitions/Inspection"
         },
         "OtherTests": {
           "$ref": "#/definitions/OtherTests"

--- a/EN10168-v1.0.schema.json
+++ b/EN10168-v1.0.schema.json
@@ -25,7 +25,23 @@
           "type": "string"
         }
       },
-      "required": ["Key", "Value"],
+      "required": ["Key"],
+      "additionalProperties": false
+    },
+    "SupplementaryInformation": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string"
+        }
+      },
+      "required": ["key", "value"],
       "additionalProperties": false
     },
     "Language": {
@@ -298,8 +314,8 @@
       "required": ["Form", "Description"],
       "additionalProperties": false
     },
-    "ProductDescription": {
-      "title": "ProductDescription",
+    "ProductShape": {
+      "title": "ProductShape",
       "oneOf": [
         {
           "$ref": "#/definitions/Tube"
@@ -414,8 +430,8 @@
           "contentMediaType": "image/png"
         },
         "A05": {
+          "allOf": [{ "$ref": "#/definitions/Company" }],
           "description": "The originator of the document, not necessarily equal to A01",
-          "type": "string",
           "default": "Factory Production Control"
         },
         "A06": {
@@ -449,12 +465,22 @@
         "SupplementaryInformation": {
           "title": "CommercialTransactionSupplementaryInformation",
           "type": "object",
+          "propertyNames": {
+            "pattern": "^A1[0-9]|^A[2-8][0-9]|^A[2-9][0-7]"
+          },
           "patternProperties": {
             "A1[0-9]|A[2-8][0-9]|A[2-9][0-7]": {
-              "$ref": "#/definitions/KeyValueObject"
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/SupplementaryInformation"
+                },
+                {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              ]
             }
           },
-          "additionalProperties": false
+          "additionalProperties": true
         },
         "A97": {
           "description": "The position number in the order",
@@ -667,18 +693,28 @@
         "SupplementaryInformation": {
           "title": "ChemicalCompositionSupplementaryInformation",
           "type": "object",
+          "propertyNames": {
+            "pattern": "^C[7-9][0-9]|^C[1][0][0-9]"
+          },
           "patternProperties": {
             "C[7-9][0-9]|C[1][0][0-9]": {
-              "$ref": "#/definitions/KeyValueObject"
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/SupplementaryInformation"
+                },
+                {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              ]
             }
           },
-          "additionalProperties": false
+          "additionalProperties": true
         }
       },
       "additionalProperties": false
     },
-    "CertificateProductDescription": {
-      "title": "CertificateProductDescription",
+    "ProductDescription": {
+      "title": "ProductDescription",
       "type": "object",
       "properties": {
         "B01": {
@@ -745,7 +781,7 @@
           "type": "number"
         },
         "B09": {
-          "allOf": [{ "$ref": "#/definitions/ProductDescription" }],
+          "allOf": [{ "$ref": "#/definitions/ProductShape" }],
           "description": "Product type and its describing dimensional parameters"
         },
         "B10": {
@@ -765,11 +801,21 @@
           "type": "number"
         },
         "SupplementaryInformation": {
-          "title": "CertificateProductDescriptionSupplementaryInformation",
+          "title": "ProductDescriptionSupplementaryInformation",
           "type": "object",
+          "propertyNames": {
+            "pattern": "^B1[4-9]|^B[2-9][0-9]"
+          },
           "patternProperties": {
-            "B1[4-9]|B[2-9][0-9]": {
-              "$ref": "#/definitions/KeyValueObject"
+            "^B1[4-9]|^B[2-9][0-9]": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/SupplementaryInformation"
+                },
+                {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              ]
             }
           },
           "additionalProperties": false
@@ -801,9 +847,19 @@
         "SupplementaryInformation": {
           "title": "InspectionSupplementaryInformation",
           "type": "object",
+          "propertyNames": {
+            "pattern": "^C0[4-9]"
+          },
           "patternProperties": {
             "^C0[4-9]": {
-              "$ref": "#/definitions/KeyValueObject"
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/SupplementaryInformation"
+                },
+                {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              ]
             }
           },
           "additionalProperties": false
@@ -831,9 +887,19 @@
             "SupplementaryInformation": {
               "title": "TensileTestSupplementaryInformation",
               "type": "object",
+              "propertyNames": {
+                "pattern": "^C1[4-9]|^C2[0-9]"
+              },
               "patternProperties": {
-                "^C1[4-9]|C2[0-9]": {
-                  "$ref": "#/definitions/KeyValueObject"
+                "^C1[4-9]|^C2[0-9]": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/SupplementaryInformation"
+                    },
+                    {
+                      "$ref": "#/definitions/KeyValueObject"
+                    }
+                  ]
                 }
               }
             }
@@ -861,9 +927,19 @@
             "SupplementaryInformation": {
               "title": "HardnessTestSupplementaryInformation",
               "type": "object",
+              "propertyNames": {
+                "pattern": "^C3[3-9]"
+              },
               "patternProperties": {
                 "^C3[3-9]": {
-                  "$ref": "#/definitions/KeyValueObject"
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/SupplementaryInformation"
+                    },
+                    {
+                      "$ref": "#/definitions/KeyValueObject"
+                    }
+                  ]
                 }
               }
             }
@@ -895,9 +971,19 @@
             "SupplementaryInformation": {
               "title": "NotchedBarImpactTestSupplementaryInformation",
               "type": "object",
+              "propertyNames": {
+                "pattern": "^C4[4-9]"
+              },
               "patternProperties": {
                 "^C4[4-9]": {
-                  "$ref": "#/definitions/KeyValueObject"
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/SupplementaryInformation"
+                    },
+                    {
+                      "$ref": "#/definitions/KeyValueObject"
+                    }
+                  ]
                 }
               }
             }
@@ -906,9 +992,19 @@
         "OtherMechanicalTests": {
           "title": "OtherMechanicalTests",
           "type": "object",
+          "propertyNames": {
+            "pattern": "^C[5-6][0-9]"
+          },
           "patternProperties": {
             "^C[5-6][0-9]": {
-              "$ref": "#/definitions/KeyValueObject"
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/SupplementaryInformation"
+                },
+                {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              ]
             }
           }
         },
@@ -964,9 +1060,19 @@
         "SupplementaryInformation": {
           "title": "ValidationSupplementaryInformation",
           "type": "object",
+          "propertyNames": {
+            "pattern": "^Z0[5-9]|^Z[1-9][0-9]"
+          },
           "patternProperties": {
-            "Z0[5-9]|Z[1-9][0-9]": {
-              "$ref": "#/definitions/KeyValueObject"
+            "^Z0[5-9]|^Z[1-9][0-9]": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/SupplementaryInformation"
+                },
+                {
+                  "$ref": "#/definitions/KeyValueObject"
+                }
+              ]
             }
           }
         }
@@ -1015,7 +1121,7 @@
           "$ref": "#/definitions/CommercialTransaction"
         },
         "ProductDescription": {
-          "$ref": "#/definitions/CertificateProductDescription"
+          "$ref": "#/definitions/ProductDescription"
         },
         "Inspection": {
           "$ref": "#/definitions/Inspection"
@@ -1032,8 +1138,18 @@
               "title": "NonDestructiveTests",
               "type": "object",
               "patternProperties": {
+                "propertyNames": {
+                  "pattern": "^D[0][2-9]|^D[1-4]D[0-9]"
+                },
                 "^D[0][2-9]|^D[1-4]D[0-9]": {
-                  "$ref": "#/definitions/KeyValueObject"
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/SupplementaryInformation"
+                    },
+                    {
+                      "$ref": "#/definitions/KeyValueObject"
+                    }
+                  ]
                 }
               },
               "additionalProperties": false
@@ -1041,9 +1157,19 @@
             "SupplementaryInformation": {
               "title": "OtherTestsSupplementaryInformation",
               "type": "object",
+              "propertyNames": {
+                "pattern": "^D[5-9][0-9]"
+              },
               "patternProperties": {
                 "^D[5-9][0-9]": {
-                  "$ref": "#/definitions/KeyValueObject"
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/SupplementaryInformation"
+                    },
+                    {
+                      "$ref": "#/definitions/KeyValueObject"
+                    }
+                  ]
                 }
               },
               "additionalProperties": false


### PR DESCRIPTION
While working on TS interfaces / type generation using the json schema as input, i noticed minor issues : 
- some `additionalProperties` misplaced in the tree
- properties using `$ref` and `description` which created issues during the generation process
example , for properties like A01

```json
“A01”: {
    “$ref”: “#/definitions/Company”,
    “description”: “The receiver/consignee of the certificate”
}
```

this property is not parsed properly and i used different tools that outputs the completely resolved object, like :

```ts
/**
* The manufacturer’s works which delivers the certificate along the product
*/
A01?: {
        CompanyName: string;
        Street: string;
        ZipCode: string;
        City: string;
        Country: string;
        VAT_Id?: string;
        Email: string;
        CertificateLanguage?: [“EN” | “DE” | “FR” | “PL”] | [“EN” | “DE” | “FR” | “PL”, “EN” | “DE” | “FR” | “PL”];
        /**
         * Each entry to the array is rendered as a new line in HTML and PDF
         */
        AdditionalInformation?: string[];
        [k: string]: unknown;
};
```

But instead what we want is something like:
```ts
/**
* The manufacturer’s works which delivers the certificate along the product
*/
A01?: Company;
```

Then i found this on stackoverflow, that suggests that we should declare our $ref like this instead :
```json
“A01": {
   “allOf”: [{ “$ref”: “#/definitions/Company” }],
    “description”: “The receiver/consignee of the certificate”
}
```

- I also refactored the certificate properties by setting 'big' property as separate definitions.

There is some naming conflict with the certificate property `ProductDescription` which is also used as definition name for `B09`, so i called the definition `CertificateProductDescription`.

I tested with the validation module from [EN10168 repo](https://github.com/s1seven/EN10168), it works fine.
You can also test by pulling and switching to this branch locally, and run from the root of EN10168 repo

```bash
npm run validate <path-to-schemas-repo>/schemas/EN10168-v1.0.schema.json
```
