### PR TITLE
Fix schema

### DIFF
--- a/EN10168.schema.json
+++ b/EN10168.schema.json
@@ -1376,7 +1376,8 @@
     }
   },
   "required": [
-    "Certificate"
+    "Certificate",
+    "SchemaReference"
   ],
   "additionalProperties": false
 }

--- a/update-version.js
+++ b/update-version.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const { promisify } = require('util');
 
-const serverUrl = 'https://raw.githubusercontent.com/s1seven/schemas/';
+const serverUrl = 'https://raw.githubusercontent.com/s1seven/schemas';
 
 function readFile(path) {
   return promisify(fs.readFile)(path, 'utf8');


### PR DESCRIPTION
Small fix:
- `$id` path was containing 2 slashes
- more important `SchemaReference` was not required, but it will be mandatory to have it to be able to validate the schema, load the appropriate translations and template files